### PR TITLE
Minor refactor & convention clean up

### DIFF
--- a/lib/reader.rb
+++ b/lib/reader.rb
@@ -14,8 +14,7 @@ class Reader
   end
 
   def decode_file_from_braille
-    incoming_text = file_manager.read
-    decoded = decode_from_braille(incoming_text)
+    decoded = decode_from_braille(file_manager.read)
     file_manager.write(decoded)
   end
 

--- a/lib/reader.rb
+++ b/lib/reader.rb
@@ -14,8 +14,7 @@ class Reader
   end
 
   def decode_file_from_braille
-    decoded = decode_from_braille(file_manager.read)
-    file_manager.write(decoded)
+    file_manager.write(decode_from_braille(file_manager.read))
   end
 
   def decode_from_braille(input)

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -1,12 +1,4 @@
 module Translator
-  def braillify_english(input)
-    input.flat_map do |string|
-      string.chomp.chars.map do |char|
-        dictionary.letter_to_braille[char]
-      end
-    end
-  end
-
   def build_braille_rows(input)
     braille_rows = Hash.new { |braille_rows, line| braille_rows[line] = [] }
     braillify_english(input).each do |pair|
@@ -15,6 +7,14 @@ module Translator
       braille_rows[:btm] << pair.chars[4..5]
     end
     join_braille_rows(braille_rows)
+  end
+
+  def braillify_english(input)
+    input.flat_map do |string|
+      string.chomp.chars.map do |char|
+        dictionary.letter_to_braille[char]
+      end
+    end
   end
 
   def join_braille_rows(input)
@@ -27,9 +27,9 @@ module Translator
   def output_braille(input)
     final_string = []
     until input[:top].empty?
-      final_string << "#{input[:top].slice!(0..79)}\n"
-      final_string << "#{input[:mid].slice!(0..79)}\n"
-      final_string << "#{input[:btm].slice!(0..79)}\n"
+      input.keys.each do |row|
+        final_string << "#{input[row].slice!(0..79)}\n"
+      end
     end
     final_string.join.chomp
   end

--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -8,13 +8,13 @@ module Translator
   end
 
   def build_braille_rows(input)
-    row_hash = Hash.new { |row_hash, line| row_hash[line] = [] }
+    braille_rows = Hash.new { |braille_rows, line| braille_rows[line] = [] }
     braillify_english(input).each do |pair|
-      row_hash[:top] << pair.chars[0..1]
-      row_hash[:mid] << pair.chars[2..3]
-      row_hash[:btm] << pair.chars[4..5]
+      braille_rows[:top] << pair.chars[0..1]
+      braille_rows[:mid] << pair.chars[2..3]
+      braille_rows[:btm] << pair.chars[4..5]
     end
-    join_braille_rows(row_hash)
+    join_braille_rows(braille_rows)
   end
 
   def join_braille_rows(input)
@@ -43,15 +43,15 @@ module Translator
   end
 
   def deformat_braille(input)
-    line_hash = Hash.new { |line_hash, line| line_hash[line] = [] }
+    braille_thirds = Hash.new { |braille_thirds, line| braille_thirds[line] = [] }
     input.each_cons(3) do |triplet|
       until triplet[0].size == 0
-        line_hash[:top] << triplet[0].slice!(0..1)
-        line_hash[:mid] << triplet[1].slice!(0..1)
-        line_hash[:btm] << triplet[2].slice!(0..1)
+        braille_thirds[:top] << triplet[0].slice!(0..1)
+        braille_thirds[:mid] << triplet[1].slice!(0..1)
+        braille_thirds[:btm] << triplet[2].slice!(0..1)
       end
     end
-    braille = line_hash[:top].zip(line_hash[:mid], line_hash[:btm])
+    braille = braille_thirds[:top].zip(braille_thirds[:mid], braille_thirds[:btm])
     stringify_braille(braille)
   end
 

--- a/lib/writer.rb
+++ b/lib/writer.rb
@@ -14,12 +14,10 @@ class Writer
   end
 
   def encode_file_to_braille
-    encoded = encode_to_braille(file_manager.read)
-    file_manager.write(encoded)
+    file_manager.write(encode_to_braille(file_manager.read))
   end
 
   def encode_to_braille(input)
-    braille_by_row = build_braille_rows(input)
-    output_braille(braille_by_row)
+    output_braille(build_braille_rows(input))
   end
 end

--- a/lib/writer.rb
+++ b/lib/writer.rb
@@ -14,8 +14,7 @@ class Writer
   end
 
   def encode_file_to_braille
-    incoming_text = file_manager.read
-    encoded = encode_to_braille(incoming_text)
+    encoded = encode_to_braille(file_manager.read)
     file_manager.write(encoded)
   end
 

--- a/lib/writer.rb
+++ b/lib/writer.rb
@@ -14,9 +14,9 @@ class Writer
   end
 
   def encode_file_to_braille
-      incoming_text = file_manager.read
-      encoded = encode_to_braille(incoming_text)
-      file_manager.write(encoded)
+    incoming_text = file_manager.read
+    encoded = encode_to_braille(incoming_text)
+    file_manager.write(encoded)
   end
 
   def encode_to_braille(input)


### PR DESCRIPTION
- match ruby conventions
- in reader & writer, drop encode/decode to one line
- refactor translator methods to iteration where possible
- rename variables